### PR TITLE
docs: improve backend comment accuracy and clarity

### DIFF
--- a/src-tauri/src/commands/batch.rs
+++ b/src-tauri/src/commands/batch.rs
@@ -1,9 +1,10 @@
 // commands/batch.rs - Batch Encryption/Decryption Commands
 //
 // This module implements batch processing for multiple files.
-// Each file is encrypted/decrypted independently:
-// - A unique salt is generated per encrypted file, so Argon2id key derivation runs per file.
-// - The `Password` wrapper is reused across the batch to avoid repeated allocations.
+// Each file is encrypted/decrypted independently with its own unique encryption key:
+// - A unique salt is generated per file
+// - Argon2id key derivation runs separately for each file, producing different keys
+// - The `Password` wrapper is reused across the batch to avoid repeated allocations
 //
 // Progress events are emitted for each file being processed.
 
@@ -251,8 +252,9 @@ where
 
 /// Encrypt multiple files with the same password
 ///
-/// This command efficiently encrypts multiple files by deriving the key once.
-/// Each file gets its own unique salt for security.
+/// Each file is encrypted independently with its own unique salt, which means
+/// a new encryption key is derived for each file (via Argon2id KDF).
+/// This ensures files encrypted with the same password have different keys.
 ///
 /// # Arguments
 /// * `app` - Tauri app handle for emitting progress events

--- a/src-tauri/src/commands/file_utils.rs
+++ b/src-tauri/src/commands/file_utils.rs
@@ -189,7 +189,7 @@ pub fn validate_input_path(path: &str) -> CryptoResult<PathBuf> {
     validate_no_symlinks(path)?;
 
     // Reject non-regular files (directories, devices, FIFOs, etc.).
-    // Size limits are enforced by callers (streaming vs in-memory paths).
+    // All files are processed via streaming encryption with chunking.
     let metadata = fs::metadata(path)?;
     if !metadata.file_type().is_file() {
         return Err(CryptoError::InvalidPath(

--- a/src-tauri/src/crypto/kdf.rs
+++ b/src-tauri/src/crypto/kdf.rs
@@ -65,7 +65,7 @@ const PARALLELISM: u32 = 4;
 const KEY_LENGTH: usize = 32;
 
 /// Salt length in bytes (16 bytes = 128 bits is standard)
-/// This is public to allow consistent validation across all encryption modes
+/// This is public to allow consistent validation across streaming encryption operations
 pub const SALT_LENGTH: usize = 16;
 
 const MIN_MEMORY_COST: u32 = 8 * 1024;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -33,7 +33,7 @@ pub enum CryptoError {
     #[error("File error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// File too large for in-memory processing
+    /// File too large for processing (exceeds maximum chunk count)
     #[error("FileTooLarge: {0}")]
     FileTooLarge(String),
 


### PR DESCRIPTION
This commit addresses inconsistencies and clarity issues found during
code review of the backend (src-tauri) Rust code.

Changes:
- Fix incorrect batch.rs comment claiming key is derived once (it's
  derived per file with unique salts)
- Remove outdated references to "in-memory processing" in error.rs
  and file_utils.rs (all operations now use streaming)
- Clarify batch operations derive different keys per file
- Improve timestamp mixing rationale in streaming.rs (defense-in-depth)
- Clarify empty file handling ensures password validation
- Make kdf.rs SALT_LENGTH comment more specific about streaming

All changes are documentation-only and do not affect functionality.